### PR TITLE
Document virtualenvs as another reason to avoid auto-generated man pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,10 +52,23 @@ This approach of installing man pages is problematic for various reasons:
 
 Python in general and with that pip and setuptools are aimed to be platform independent.
 Man pages are **not**: they are a UNIX thing which means setuptools does not provide a sane
-solution to generate and install man pages.
+solution to generate and install man pages. 
 We should consider using automatic man page installation only with vendor specific packaging, e.g. for `*.deb` or `*.rpm` packages.
 
-#### (2) We want to generate man pages on the fly
+#### (2) Man pages are not compatable with Python virtualenvs
+
+Even on systems that support man pages, Python packages can be installed in
+virtualenvs via pip and setuptools, which do not make commands available
+globally. In fact, one of the "features" of a virtualenv is the ability to
+install a package without affecting the main system. As it is imposable to
+ensure a man page is only generated when not installing into a virtualenv,
+auto-generated man pages would pollute the main system and not stay contained in
+the virtualenv. Additionally, as a user could install multiple different
+versions of the same package into multiple different virtualenvs on the same
+system, there is no guarantee that a globally installed man page will document
+the version and behavior available in any given virtualenv.
+
+#### (3) We want to generate man pages on the fly
 
 First, we do not want to commit man pages to our source control.
 We want to generate them on the fly. Either
@@ -64,7 +77,7 @@ during build or installation time.
 With setuptools and pip we face two problems:
 
 1. If we generate and install them during installation of the package pip does not know about the man pages and thus cannot uninstall it.
-2. If we generate them in our build process and add them to your distribution we do not have a way to prevent installation to */usr/share/man* for non-UNIX-like Operating Systems.
+2. If we generate them in our build process and add them to your distribution we do not have a way to prevent installation to */usr/share/man* for non-UNIX-like Operating Systems or from within virtualenvs.
 
 ### Debian packages
 


### PR DESCRIPTION
I realize not everyone uses virtualenvs, but every package maintainer should expect that at least some of their users will want to install a package in a virtualenv. Even on a system that supports man pages, you don't want man pages for packages installed in virtualenvs.