### PR TITLE
Add CLI tool.

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,23 @@ pip install click-man
 
 The following sections describe different usage example for *click-man*.
 
+### Use with a previously installed package
+
+**click-man** provides its own command line tool which can be passed the name of
+an installed script:
+
+```bash
+click-man commandname
+```
+
+where `commandname` is the name of an installed `console_script` entry point.
+
+To specify a target directory for the man pages, use the `--target` option:
+
+```bash
+click-man --target path/to/man/pages commandname
+```
+
 ### Use with setuptools
 
 **click-man** provides a sane setuptools command extension which can be used like the following:

--- a/click_man/__main__.py
+++ b/click_man/__main__.py
@@ -1,0 +1,53 @@
+"""
+click-man - Generate man pages for click application
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This module provides a click CLI command to
+generate man pages from a click application.
+
+:copyright: (c) 2016 by Timo Furrer.
+:license: MIT, see LICENSE for more details.
+"""
+
+import os
+import click
+from pkg_resources import iter_entry_points, get_distribution
+
+from click_man.core import write_man_pages
+
+
+@click.command(context_settings={'help_option_names': ['-h', '--help']})
+@click.option('--target', '-t', default=os.path.join(os.getcwd(), 'man'),
+              type=click.Path(file_okay=False, dir_okay=True, resolve_path=True),
+              help='Target location for the man pages')
+@click.version_option(get_distribution('click-man').version, '-V', '--version')
+@click.argument('name')
+def cli(target, name):
+    """
+    Generate man pages for the scripts defined in the ``console_acripts`` entry point.
+
+    The cli application is gathered from entry points of installed packages.
+
+    The generated man pages are written to files in the directory given
+    by ``--target``.
+    """
+    console_scripts = [ep for ep in iter_entry_points('console_scripts', name=name)]
+    if len(console_scripts) < 1:
+        raise click.ClickException('"{0}" is not an installed console script.'.format(name))
+    # Only generate man pages for first console script
+    entry_point = console_scripts[0]
+    
+    # create target directory if it does not exist yet
+    try:
+        os.makedirs(target)
+    except OSError:
+        pass
+
+    click.echo('Load entry point {0}'.format(name))
+    cli = entry_point.resolve()
+    click.echo('Generate man pages for {0} in {1}'.format(name, target))
+    write_man_pages(name, cli, version=entry_point.dist.version, target_dir=target)
+
+
+if __name__ == '__main__':
+    cli()

--- a/setup.py
+++ b/setup.py
@@ -10,5 +10,10 @@ setup(
     install_requires=[
         'click'
     ],
-    packages=find_packages()
+    packages=find_packages(),
+    entry_points={
+        'console_scripts': [
+            'click-man = click_man.__main__:cli',
+        ]
+    }
 )


### PR DESCRIPTION
A click application which takes a `console_scripts` entry point for an
installed application and generates man pages. Addresses #15.

A few notes:

1. This only works on installed packages which use `console_scripts` entry points and is useful for end users who have installed packages via pip (likely from a `.whl` file) and do not have access to a `setup.py` script.
2. The pre-existing setuptools command can co-exist as it only works from a `septup.py` script which presumably has not been installed and is useful to OS level package maintainers and the like.
3. The `-V/--version` option simply reports click-man's version and exits, unlike the pre-existing setuptools command which uses the `--version` option for the version of the "command" in the man pages.
4. The version of the "command" for use in the man pages is determined from the "Distribution" of the entry point  (`entry_point.dist.version`).
