### PR TITLE
Handle unset 'Command.short_help'

### DIFF
--- a/click_man/core.py
+++ b/click_man/core.py
@@ -35,7 +35,7 @@ def generate_man_page(ctx, version=None):
     man_page.options = [x.get_help_record(None) for x in ctx.command.params if isinstance(x, click.Option)]
     commands = getattr(ctx.command, 'commands', None)
     if commands:
-        man_page.commands = [(k, v.short_help) for k, v in commands.items()]
+        man_page.commands = [(k, v.short_help or v.help) for k, v in commands.items()]
 
     return str(man_page)
 


### PR DESCRIPTION
There appears to be a bug in Click 7.0 that has the 'short_help' value
unset, meaning we see the following exceptions:

  AttributeError: 'NoneType' object has no attribute 'split'

Resolve this with a simply falling back to 'help' if 'short_help' is
unset. This means we continue to work with all versions of Click, even
though the proper fix should be in Click itself.

Signed-off-by: Stephen Finucane <stephen@that.guru>
Closes: #21