### PR TITLE
Generate man pages for all entry points

### DIFF
--- a/click_man/commands/man_pages.py
+++ b/click_man/commands/man_pages.py
@@ -59,11 +59,9 @@ class man_pages(Command):
             raise DistutilsSetupError('No entry points defined in setup()')
 
         console_scripts = [(k, v) for k, v in eps['console_scripts'].items()]
-        # Only generate man pages for first console script
         # FIXME: create own setup() attribute for CLI script configuration
-        name, entry_point = console_scripts[0]
-
-        self.announce('Load entry point {0}'.format(name), level=2)
-        cli = entry_point.resolve()
-        self.announce('Generate man pages for {0}'.format(name), level=2)
-        write_man_pages(name, cli, version=self.version, target_dir=self.target)
+        for name, entry_point in console_scripts:
+            self.announce('Load entry point {0}'.format(name), level=2)
+            cli = entry_point.resolve()
+            self.announce('Generate man pages for {0}'.format(name), level=2)
+            write_man_pages(name, cli, version=self.version, target_dir=self.target)


### PR DESCRIPTION
Previously we used to generate man pages for only the first entry point.
That made it difficult to use this library in setups that needed
multiple entry points. Fix it such that we now loop over all entry
points and generate man pages for each of them.

Fixes #10.