### PR TITLE
Do not write man pages for 'hidden' commands

### DIFF
--- a/click_man/core.py
+++ b/click_man/core.py
@@ -15,6 +15,7 @@ import click
 
 from .man import ManPage
 
+CLICK_VERSION = tuple(int(x) for x in click.__version__.split('.'))
 
 def generate_man_page(ctx, version=None):
     """
@@ -65,4 +66,8 @@ def write_man_pages(name, cli, parent_ctx=None, version=None, target_dir=None):
 
     commands = getattr(cli, 'commands', {})
     for name, command in commands.items():
+        if CLICK_VERSION >= (7, 0):  # Since Click 7.0, we have been able to mark commands as hidden
+            if command.hidden:
+                # Do not write a man page for a hidden command
+                continue
         write_man_pages(name, command, parent_ctx=ctx, version=version, target_dir=target_dir)


### PR DESCRIPTION
Since Click 7.0, we have been able to mark some commands as hidden,
this is useful for deprecating commands.

If you are using Click 7.0, `Click.Command` objects now have a Boolean 'hidden' attribute (see [here](http://click.palletsprojects.com/en/7.x/api/#click.Command)), this is used to determine whether a command has been marked as hidden or not.

This commit ensures that we do not write man pages for 'hidden' commands.

Closes #27 