### PR TITLE
fix AttributeError when help arg is not set

### DIFF
--- a/click_man/man.py
+++ b/click_man/man.py
@@ -55,6 +55,8 @@ class ManPage(object):
     def replace_blank_lines(self, s):
         ''' Find any blank lines and replace them with .PP '''
 
+        if not s:
+            return ""
         lines = map(lambda l: self.PARAGRAPH_KEYWORD if l == '' else l,
                     s.split('\n'))
         return '\n'.join(lines)


### PR DESCRIPTION
```
$ python3 setup.py --command-packages=click_man.commands man_pages
running man_pages
Load entry point packit
Generate man pages for packit

Traceback (most recent call last):
  File "setup.py", line 27, in <module>
    setup(use_scm_version=True)
  File "/usr/lib/python3.7/site-packages/setuptools/__init__.py", line 145, in setup
    return distutils.core.setup(**attrs)
  File "/usr/lib64/python3.7/distutils/core.py", line 148, in setup
    dist.run_commands()
  File "/usr/lib64/python3.7/distutils/dist.py", line 966, in run_commands
    self.run_command(cmd)
  File "/usr/lib64/python3.7/distutils/dist.py", line 985, in run_command
    cmd_obj.run()
  File "/usr/lib/python3.7/site-packages/click_man/commands/man_pages.py", line 69, in run
    write_man_pages(name, cli, version=self.version, target_dir=self.target)
  File "/usr/lib/python3.7/site-packages/click_man/core.py", line 56, in write_man_pages
    man_page = generate_man_page(ctx, version)
  File "/usr/lib/python3.7/site-packages/click_man/core.py", line 40, in generate_man_page
    return str(man_page)
  File "/usr/lib/python3.7/site-packages/click_man/man.py", line 104, in __str__
    lines.append('  ' + self.replace_blank_lines(description))
  File "/usr/lib/python3.7/site-packages/click_man/man.py", line 61, in replace_blank_lines
    s.split('\n'))
AttributeError: 'NoneType' object has no attribute 'split'
```