### PR TITLE
Some fixes to the way click-man interfaces with click

### DIFF
--- a/click_man/__main__.py
+++ b/click_man/__main__.py
@@ -45,6 +45,22 @@ def cli(target, name):
 
     click.echo('Load entry point {0}'.format(name))
     cli = entry_point.resolve()
+
+    # If the entry point isn't a click.Command object, try to find it in the module
+    if not isinstance(cli, click.Command):
+        from importlib import import_module
+        from inspect import getmembers
+
+        if not entry_point.module_name:
+            raise click.ClickException('Could not find module name for "{0}".'.format(name))
+        ep_module = import_module(entry_point.module_name)
+        ep_members = getmembers(ep_module, lambda x: isinstance(x, click.Command))
+
+        if len(ep_members) < 1:
+            raise click.ClickException('Could not find click.Command object for "{0}".'.format(name))
+        (ep_name, cli) = ep_members[0]
+        click.echo('Found alternate entry point {0} in {1}'.format(ep_name, name))
+
     click.echo('Generate man pages for {0} in {1}'.format(name, target))
     write_man_pages(name, cli, version=entry_point.dist.version, target_dir=target)
 

--- a/click_man/core.py
+++ b/click_man/core.py
@@ -10,12 +10,11 @@ generate man pages for entire click applications.
 """
 
 import os
+from distutils.version import LooseVersion
 
 import click
 
 from .man import ManPage
-
-CLICK_VERSION = tuple(int(x) for x in click.__version__.split('.'))
 
 def generate_man_page(ctx, version=None):
     """
@@ -66,7 +65,8 @@ def write_man_pages(name, cli, parent_ctx=None, version=None, target_dir=None):
 
     commands = getattr(cli, 'commands', {})
     for name, command in commands.items():
-        if CLICK_VERSION >= (7, 0):  # Since Click 7.0, we have been able to mark commands as hidden
+        if LooseVersion(click.__version__) >= LooseVersion("7.0"):
+            # Since Click 7.0, we have been able to mark commands as hidden
             if command.hidden:
                 # Do not write a man page for a hidden command
                 continue

--- a/click_man/core.py
+++ b/click_man/core.py
@@ -32,7 +32,7 @@ def generate_man_page(ctx, version=None):
     man_page.short_help = ctx.command.get_short_help_str()
     man_page.description = ctx.command.help
     man_page.synopsis = ' '.join(ctx.command.collect_usage_pieces(ctx))
-    man_page.options = [x.get_help_record(None) for x in ctx.command.params if isinstance(x, click.Option)]
+    man_page.options = [x.get_help_record(ctx) for x in ctx.command.params if isinstance(x, click.Option)]
     commands = getattr(ctx.command, 'commands', None)
     if commands:
         man_page.commands = [


### PR DESCRIPTION
This PR corrects some issues I ran into trying to run `click-man` on _Black_'s command-line tool `black`, using the latest development version of Click.

1. Click can have a version string like `"8.0.dev"` which breaks the attempted numeric parsing. Switch to using `distutils.version.LooseVersion()` for version comparisons, instead.
1. The `click.Context` has to be passed in to `get_help_record()`, or it can sometimes throw an exception.
1. A tool's entry point isn't always its `click.Command` object.

The last item is the really ugly one: `black` has as its entry point `black:patched_main`, which as the name implies does some monkeypatching of its environment before finally calling its _actual_ `black:main`, which is the `click.Command` object for the module.

Since `isinstance(black.patched_main, click.Command)` is **`False`**, trying to turn it into a `click.Context()` breaks.

But with a bit of work, and help from `importlib` and `inspect`, we can search the `entry_point.module_name` module for a `click.Command` object, wherever it may be hiding.

Note that this may _still_ break, or do the wrong thing, if a tool's `entry_point` isn't a `click.Command` object **_and_** it has _multiple_ `click.Command` objects in its module. But hopefully that combination is an exceedingly rare case.