### PR TITLE
Travis CI: Drop Python 3.3, 3.4; add 3.7, 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,10 @@ language: python
 python:
     - '2.7'
     - pypy
-    - '3.3'
-    - '3.4'
     - '3.5'
     - '3.6'
+    - '3.7'
+    - '3.8'
 
 install:
     - python setup.py build sdist


### PR DESCRIPTION
Travis doesn't appear to support Python 3.3 _at all_ anymore, and `colorama` explicitly doesn't support Python 3.4, so both of those jobs are failing during the CI run.

This PR just drops those versions, and adds 3.7 and 3.8 in their place.