### PR TITLE
Allow to override build date with SOURCE_DATE_EPOCH

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,10 @@ language: python
 python:
     - '2.7'
     - pypy
-    - '3.3'
-    - '3.4'
     - '3.5'
     - '3.6'
+    - '3.7'
+    - '3.8'
 
 install:
     - python setup.py build sdist

--- a/click_man/man.py
+++ b/click_man/man.py
@@ -10,7 +10,8 @@ about a CLI application.
 :license: MIT, see LICENSE for more details.
 """
 
-from datetime import datetime
+import os
+import time
 
 
 class ManPage(object):
@@ -50,7 +51,7 @@ class ManPage(object):
         self.commands = []
 
         #: Holds the date of the man page creation time.
-        self.date = datetime.now().strftime("%d-%b-%Y")
+        self.date = time.strftime("%Y-%m-%d", time.gmtime(int(os.environ.get('SOURCE_DATE_EPOCH', time.time()))))
 
     def replace_blank_lines(self, s):
         ''' Find any blank lines and replace them with .PP '''


### PR DESCRIPTION
Allow to override build date with `SOURCE_DATE_EPOCH`
in order to make builds reproducible.
See https://reproducible-builds.org/ for why this is good
and https://reproducible-builds.org/specs/source-date-epoch/
for the definition of this variable.

Also use ISO 8601 date format to be understood everywhere.
Also use `gmtime` to be independent of timezone.

This PR was done while working on reproducible builds for openSUSE.