### PR TITLE
Support commands with hidden options

### DIFF
--- a/click_man/core.py
+++ b/click_man/core.py
@@ -32,7 +32,12 @@ def generate_man_page(ctx, version=None):
     man_page.short_help = ctx.command.get_short_help_str()
     man_page.description = ctx.command.help
     man_page.synopsis = ' '.join(ctx.command.collect_usage_pieces(ctx))
-    man_page.options = [x.get_help_record(ctx) for x in ctx.command.params if isinstance(x, click.Option)]
+    man_page.options = [
+        y for y in
+        [x.get_help_record(ctx) for x in ctx.command.params
+         if isinstance(x, click.Option)]
+        if y
+    ]
     commands = getattr(ctx.command, 'commands', None)
     if commands:
         man_page.commands = [


### PR DESCRIPTION
When an option has hidden=True set, Option.get_help_record returns None. Simply filter these out to avoid a later failure when trying to unpack helptext.

I wanted to add a test for this, but there doesn't seem to be a framework for it.
You can check it on any command where `hidden=True` on an option.

The issue which crops up without this is here:
https://github.com/click-contrib/click-man/blob/3e5a73bda22a8a6ae2e169385173723a11b17409/click_man/man.py#L91

Unpacking that tuple fails if the value is `None`.